### PR TITLE
docs: update amount breakdown and money documentation formatting

### DIFF
--- a/doc/models/amount-breakdown.md
+++ b/doc/models/amount-breakdown.md
@@ -1,4 +1,3 @@
-
 # Amount Breakdown
 
 The breakdown of the amount. Breakdown provides details such as total item amount, total tax amount, shipping, handling, insurance, and discounts, if any.
@@ -9,40 +8,39 @@ The breakdown of the amount. Breakdown provides details such as total item amoun
 
 ## Fields
 
-| Name | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `itemTotal` | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
-| `shipping` | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
-| `handling` | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
-| `taxTotal` | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
-| `insurance` | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
+| Name               | Type                                              | Tags     | Description                                                                            |
+| ------------------ | ------------------------------------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `itemTotal`        | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
+| `shipping`         | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
+| `handling`         | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
+| `taxTotal`         | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
+| `insurance`        | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
 | `shippingDiscount` | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
-| `discount` | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
+| `discount`         | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
 
 ## Example (as JSON)
 
 ```json
 {
-  "item_total": {
-    "currency_code": "currency_code0",
+  "itemTotal": {
+    "currencyCode": "currencyCode0",
     "value": "value6"
   },
   "shipping": {
-    "currency_code": "currency_code0",
+    "currencyCode": "currencyCode0",
     "value": "value6"
   },
   "handling": {
-    "currency_code": "currency_code2",
+    "currencyCode": "currencyCode2",
     "value": "value8"
   },
-  "tax_total": {
-    "currency_code": "currency_code4",
+  "taxTotal": {
+    "currencyCode": "currencyCode4",
     "value": "value0"
   },
   "insurance": {
-    "currency_code": "currency_code2",
+    "currencyCode": "currencyCode2",
     "value": "value8"
   }
 }
 ```
-

--- a/doc/models/item.md
+++ b/doc/models/item.md
@@ -1,4 +1,3 @@
-
 # Item
 
 The details for the items to be purchased.
@@ -9,37 +8,36 @@ The details for the items to be purchased.
 
 ## Fields
 
-| Name | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `name` | `string` | Required | The item name or title.<br>**Constraints**: *Minimum Length*: `1`, *Maximum Length*: `127` |
-| `unitAmount` | [`Money`](../../doc/models/money.md) | Required | The currency and amount for a financial transaction, such as a balance or payment due. |
-| `tax` | [`Money \| undefined`](../../doc/models/money.md) | Optional | The currency and amount for a financial transaction, such as a balance or payment due. |
-| `quantity` | `string` | Required | The item quantity. Must be a whole number.<br>**Constraints**: *Maximum Length*: `10`, *Pattern*: `^[1-9][0-9]{0,9}$` |
-| `description` | `string \| undefined` | Optional | The detailed item description.<br>**Constraints**: *Maximum Length*: `127` |
-| `sku` | `string \| undefined` | Optional | The stock keeping unit (SKU) for the item.<br>**Constraints**: *Maximum Length*: `127` |
-| `url` | `string \| undefined` | Optional | The URL to the item being purchased. Visible to buyer and used in buyer experiences.<br>**Constraints**: *Minimum Length*: `1`, *Maximum Length*: `2048` |
-| `category` | [`ItemCategory \| undefined`](../../doc/models/item-category.md) | Optional | The item category type.<br>**Constraints**: *Minimum Length*: `1`, *Maximum Length*: `20` |
-| `imageUrl` | `string \| undefined` | Optional | The URL of the item's image. File type and size restrictions apply. An image that violates these restrictions will not be honored.<br>**Constraints**: *Minimum Length*: `1`, *Maximum Length*: `2048`, *Pattern*: `^(https:)([/\|.\|\w\|\s\|-])*\.(?:jpg\|gif\|png\|jpeg\|JPG\|GIF\|PNG\|JPEG)` |
-| `upc` | [`UniversalProductCode \| undefined`](../../doc/models/universal-product-code.md) | Optional | The Universal Product Code of the item. |
+| Name          | Type                                                                              | Tags     | Description                                                                                                                                                                                                                                                                                      |
+| ------------- | --------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`        | `string`                                                                          | Required | The item name or title.<br>**Constraints**: _Minimum Length_: `1`, _Maximum Length_: `127`                                                                                                                                                                                                       |
+| `unitAmount`  | [`Money`](../../doc/models/money.md)                                              | Required | The currency and amount for a financial transaction, such as a balance or payment due.                                                                                                                                                                                                           |
+| `tax`         | [`Money \| undefined`](../../doc/models/money.md)                                 | Optional | The currency and amount for a financial transaction, such as a balance or payment due.                                                                                                                                                                                                           |
+| `quantity`    | `string`                                                                          | Required | The item quantity. Must be a whole number.<br>**Constraints**: _Maximum Length_: `10`, _Pattern_: `^[1-9][0-9]{0,9}$`                                                                                                                                                                            |
+| `description` | `string \| undefined`                                                             | Optional | The detailed item description.<br>**Constraints**: _Maximum Length_: `127`                                                                                                                                                                                                                       |
+| `sku`         | `string \| undefined`                                                             | Optional | The stock keeping unit (SKU) for the item.<br>**Constraints**: _Maximum Length_: `127`                                                                                                                                                                                                           |
+| `url`         | `string \| undefined`                                                             | Optional | The URL to the item being purchased. Visible to buyer and used in buyer experiences.<br>**Constraints**: _Minimum Length_: `1`, _Maximum Length_: `2048`                                                                                                                                         |
+| `category`    | [`ItemCategory \| undefined`](../../doc/models/item-category.md)                  | Optional | The item category type.<br>**Constraints**: _Minimum Length_: `1`, _Maximum Length_: `20`                                                                                                                                                                                                        |
+| `imageUrl`    | `string \| undefined`                                                             | Optional | The URL of the item's image. File type and size restrictions apply. An image that violates these restrictions will not be honored.<br>**Constraints**: _Minimum Length_: `1`, _Maximum Length_: `2048`, _Pattern_: `^(https:)([/\|.\|\w\|\s\|-])*\.(?:jpg\|gif\|png\|jpeg\|JPG\|GIF\|PNG\|JPEG)` |
+| `upc`         | [`UniversalProductCode \| undefined`](../../doc/models/universal-product-code.md) | Optional | The Universal Product Code of the item.                                                                                                                                                                                                                                                          |
 
 ## Example (as JSON)
 
 ```json
 {
   "name": "name2",
-  "unit_amount": {
-    "currency_code": "currency_code2",
+  "unitAmount": {
+    "currencyCode": "currencyCode2",
     "value": "value8"
   },
   "tax": {
-    "currency_code": "currency_code0",
+    "currencyCode": "currencyCode0",
     "value": "value6"
   },
   "quantity": "quantity8",
   "description": "description2",
   "sku": "sku8",
   "url": "url6",
-  "category": "DIGITAL_GOODS"
+  "category": "DigitalGoods"
 }
 ```
-

--- a/doc/models/money.md
+++ b/doc/models/money.md
@@ -1,4 +1,3 @@
-
 # Money
 
 The currency and amount for a financial transaction, such as a balance or payment due.
@@ -9,17 +8,16 @@ The currency and amount for a financial transaction, such as a balance or paymen
 
 ## Fields
 
-| Name | Type | Tags | Description |
-|  --- | --- | --- | --- |
-| `currencyCode` | `string` | Required | The [three-character ISO-4217 currency code](/api/rest/reference/currency-codes/) that identifies the currency.<br>**Constraints**: *Minimum Length*: `3`, *Maximum Length*: `3` |
-| `value` | `string` | Required | The value, which might be:<ul><li>An integer for currencies like `JPY` that are not typically fractional.</li><li>A decimal fraction for currencies like `TND` that are subdivided into thousandths.</li></ul>For the required number of decimal places for a currency code, see [Currency Codes](/api/rest/reference/currency-codes/).<br>**Constraints**: *Maximum Length*: `32`, *Pattern*: `^((-?[0-9]+)\|(-?([0-9]+)?[.][0-9]+))$` |
+| Name           | Type     | Tags     | Description                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| -------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `currencyCode` | `string` | Required | The [three-character ISO-4217 currency code](/api/rest/reference/currency-codes/) that identifies the currency.<br>**Constraints**: _Minimum Length_: `3`, _Maximum Length_: `3`                                                                                                                                                                                                                                                        |
+| `value`        | `string` | Required | The value, which might be:<ul><li>An integer for currencies like `JPY` that are not typically fractional.</li><li>A decimal fraction for currencies like `TND` that are subdivided into thousandths.</li></ul>For the required number of decimal places for a currency code, see [Currency Codes](/api/rest/reference/currency-codes/).<br>**Constraints**: _Maximum Length_: `32`, _Pattern_: `^((-?[0-9]+)\|(-?([0-9]+)?[.][0-9]+))$` |
 
 ## Example (as JSON)
 
 ```json
 {
-  "currency_code": "currency_code6",
+  "currencyCode": "currencyCode6",
   "value": "value2"
 }
 ```
-


### PR DESCRIPTION
Update the json examples in the documentations to fit the latest type description.