### PR TITLE
Fix ESM dist export packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "node": ">=14.17.0"
   },
   "scripts": {
-    "build": "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json",
-    "prepare": "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json",
+    "build": "rimraf dist && tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json && node scripts/write-dist-package-jsons.cjs && npm run verify:dist",
+    "prepare": "npm run build",
+    "verify:dist": "node scripts/verify-dist-exports.cjs",
     "lint": "eslint **/*.ts --ignore-path .eslintignore",
     "lint:fix": "eslint **/*.ts --ignore-path .eslintignore --fix"
   },

--- a/scripts/verify-dist-exports.cjs
+++ b/scripts/verify-dist-exports.cjs
@@ -1,0 +1,26 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+async function main() {
+  const rootDir = path.resolve(__dirname, '..');
+  const cjsEntry = path.join(rootDir, 'dist', 'cjs', 'index.js');
+  const esmEntry = pathToFileURL(
+    path.join(rootDir, 'dist', 'esm', 'index.js')
+  ).href;
+
+  const cjsSdk = require(cjsEntry);
+  const esmSdk = await import(esmEntry);
+
+  assert.equal(cjsSdk.OrderStatus.Created, 'CREATED');
+  assert.equal(cjsSdk.CaptureStatus.Completed, 'COMPLETED');
+  assert.equal(esmSdk.OrderStatus.Created, 'CREATED');
+  assert.equal(esmSdk.CaptureStatus.Completed, 'COMPLETED');
+
+  console.log('Verified ESM and CJS dist exports');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/write-dist-package-jsons.cjs
+++ b/scripts/write-dist-package-jsons.cjs
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const distPackages = [
+  { dir: path.join(rootDir, 'dist', 'esm'), type: 'module' },
+  { dir: path.join(rootDir, 'dist', 'cjs'), type: 'commonjs' },
+];
+
+for (const { dir, type } of distPackages) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ type }, null, 2) + '\n'
+  );
+}


### PR DESCRIPTION
## Summary
- update the build to run the ESM and CJS compiles sequentially
- write `package.json` files into `dist/esm` and `dist/cjs` so Node resolves each output with the correct module type
- add a `verify:dist` step to confirm named exports are available from both published entrypoints

## Why
This fixes [#59](https://github.com/paypal/PayPal-TypeScript-Server-SDK/issues/59), where enums such as `CaptureStatus` were exported from source but not available to ESM consumers at runtime.

## Test plan
- [x] Run `npm install`
- [x] Run `npm run build`
- [x] Verify `import { OrderStatus, CaptureStatus } from '@paypal/paypal-server-sdk'` works in an ESM Node run
- [x] Verify `require('@paypal/paypal-server-sdk')` still works in CommonJS